### PR TITLE
Fix buildpack for new heroku/jvm release

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -28,10 +28,7 @@ if [ ! -f ${BUILD_DIR}/system.properties ]; then
 fi
 
 # install JDK
-javaVersion=$(detect_java_version ${BUILD_DIR})
-echo -n "-----> Installing OpenJDK ${javaVersion}..."
-install_java ${BUILD_DIR} ${javaVersion}
-jdk_overlay ${BUILD_DIR}
+install_java_with_overlay ${BUILD_DIR}
 echo " done"
 
 PLAY_PATH=".play"


### PR DESCRIPTION
The upstream `heroku/jvm` buildpack has changed so that it is no longer compatible with the code in this repository. This PR should fix the issue, allowing it to work again. I could not test it myself, so there might be more changes necessary. Happy to help get those sorted as well! :)